### PR TITLE
fix: update PoR doc to account mint amount precision as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ function mint(address _to, uint256 _amount) external onlyOwner {
             currentSupply =
                 currentSupply *
                 10**uint256(reserveDecimals - trueDecimals);
+            _amount = _amount * 10**uint256(reserveDecimals - trueDecimals);
+                   
         } else if (trueDecimals > reserveDecimals) {
             reserves = reserves * 10**uint256(trueDecimals - reserveDecimals);
         }


### PR DESCRIPTION
When the precision of the token is less than the reserve, The total supply as well as the amount which is to be minted should also be adjusted to the precision to properly calculate the PoR check.